### PR TITLE
Fix Angular GitHub Pages deployment (404 error)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -74,7 +74,7 @@ jobs:
           NODE_ENV=production npm run build
           cd ..
           mkdir -p final-dist/npm-angular
-          cp -r npm+angular/dist/* final-dist/npm-angular/
+          cp -r npm+angular/dist/browser/* final-dist/npm-angular/
 
       - name: Copy html+js
         run: |


### PR DESCRIPTION
## Problem
The Angular application on GitHub Pages was returning a 404 error because the files were being deployed to the wrong location.

## Root Cause
Angular's application builder (`@angular-devkit/build-angular:application`) outputs build files to `dist/browser/` instead of just `dist/`. The GitHub Actions workflow was copying from `npm+angular/dist/*`, which included the `browser` subdirectory, causing the files to end up at `/npm-angular/browser/` instead of `/npm-angular/`.

## Solution
Updated the workflow to copy from `npm+angular/dist/browser/*` instead of `npm+angular/dist/*`, ensuring the files are placed directly in the `/npm-angular/` directory.

## Testing
After merging, the Angular application should be accessible at:
https://tiro-health.github.io/web-sdk-tutorial/npm-angular/

Closes #16