### PR TITLE
Fix README to reference LICENSE file

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,4 +222,4 @@ For detailed SDK documentation, visit [Tiro Health Documentation](https://docs.t
 
 ## License
 
-[Your License Here]
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Fixes #34

## Summary
Updated the README.md file to properly reference the existing Apache License 2.0 LICENSE file instead of showing the placeholder text "[Your License Here]".

## Changes
- Changed the License section in README.md from `[Your License Here]` to `This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.`

## Testing
- Review the README.md file to verify the License section now properly references the LICENSE file
- Click the LICENSE link in the README to verify it navigates to the correct file