### PR TITLE
Remove unnecessary React global assignments

### DIFF
--- a/npm+angular/README.md
+++ b/npm+angular/README.md
@@ -5,7 +5,6 @@ This is the Angular version of the Tiro Web SDK tutorial, demonstrating how to i
 ## What this tutorial shows
 
 - How to integrate the Tiro Web SDK into an Angular application
-- Setting up React globals for SDK compatibility
 - Mounting form filler and narrative components
 - Basic Angular component lifecycle management
 
@@ -17,7 +16,7 @@ npm+angular/
 │   ├── app/
 │   │   └── app.component.ts           # Main component with SDK integration
 │   ├── index.html                     # Main HTML file
-│   ├── main.ts                        # Application bootstrap with React globals
+│   ├── main.ts                        # Application bootstrap
 │   └── styles.css                     # Global styles
 ├── angular.json                       # Angular CLI configuration
 ├── package.json                       # Dependencies and scripts
@@ -94,7 +93,7 @@ npm run test
 ### Key Implementation Details
 
 1. **Angular CLI**: This project uses the Angular CLI with the modern `@angular-devkit/build-angular:application` builder
-2. **React Compatibility**: The Tiro Web SDK requires React, which is made available globally in `main.ts`
+2. **React Compatibility**: The Tiro Web SDK requires React as a dependency in package.json
 3. **Component Integration**: The SDK components are mounted directly in the main AppComponent
 4. **Lifecycle Management**: Proper cleanup of SDK components when the Angular component is destroyed
 5. **TypeScript Integration**: Full TypeScript support for better development experience

--- a/npm+angular/src/main.ts
+++ b/npm+angular/src/main.ts
@@ -5,13 +5,5 @@ import 'zone.js';
 // Import global styles so custom classes and Tiro SDK CSS (via @import) are applied
 import './styles.css';
 
-// Import React and ReactDOM to make them available globally for Tiro Web SDK
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-
-// Make React available globally since Tiro Web SDK expects it
-(window as any).React = React;
-(window as any).ReactDOM = ReactDOM;
-
 bootstrapApplication(AppComponent)
   .catch(err => console.error(err));

--- a/npm+react/src/main.tsx
+++ b/npm+react/src/main.tsx
@@ -3,8 +3,4 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
 
-// Make React and ReactDOM available globally for Tiro Web SDK
-window.React = React;
-window.ReactDOM = ReactDOM;
-
 ReactDOM.createRoot(document.getElementById("root")!).render(<App />);

--- a/npm+react/src/vite-env.d.ts
+++ b/npm+react/src/vite-env.d.ts
@@ -1,11 +1,1 @@
 /// <reference types="vite/client" />
-
-import type React from "react";
-import type ReactDOM from "react-dom/client";
-
-declare global {
-  interface Window {
-    React: typeof React;
-    ReactDOM: typeof ReactDOM;
-  }
-}


### PR DESCRIPTION
## Summary

The Tiro Web SDK no longer requires React to be made globally available via `window.React` and `window.ReactDOM`. React only needs to be included as a dependency in `package.json`.

## Changes

- **npm+react/src/main.tsx**: Removed `window.React` and `window.ReactDOM` assignments
- **npm+react/src/vite-env.d.ts**: Removed React global type definitions
- **npm+angular/src/main.ts**: Removed React and ReactDOM global assignments and imports
- **npm+angular/README.md**: Updated documentation to remove mentions of React globals setup

## Testing

The user should verify that:
1. The React example (`npm+react`) still works correctly
2. The Angular example (`npm+angular`) still works correctly
3. All SDK components render properly without React being globally available

Fixes #36