### PR TITLE
Add SMART Web Messaging tile to main index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,6 +218,19 @@
                     <span class="tech-badge">No Build</span>
                 </div>
             </a>
+
+            <a href="html+js-smartwebmessaging/test-harness.html" class="tutorial-card">
+                <div class="tutorial-icon">🔗</div>
+                <h2 class="tutorial-title">SMART Web Messaging</h2>
+                <p class="tutorial-description">
+                    Integration example for WebView2/.NET hosts using SMART Web Messaging protocol. Includes test harness.
+                </p>
+                <div class="tutorial-tech">
+                    <span class="tech-badge">WebView2</span>
+                    <span class="tech-badge">postMessage</span>
+                    <span class="tech-badge">FHIR SDC</span>
+                </div>
+            </a>
         </div>
 
         <footer>


### PR DESCRIPTION
## Summary
- Adds a tile to the main index page linking to the new SMART Web Messaging example

## Dependencies
- Depends on #40 being merged first (adds the `html+js-smartwebmessaging` directory)

## Test plan
- [ ] Merge #40 first
- [ ] Open main index page
- [ ] Verify SMART Web Messaging tile appears
- [ ] Click tile and verify it opens the test harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)