### PR TITLE
Add deploy step for html+js-smartwebmessaging

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -80,6 +80,11 @@ jobs:
           mkdir -p final-dist/html-js
           cp -r html+js/* final-dist/html-js/
 
+      - name: Copy html+js-smartwebmessaging
+        run: |
+          mkdir -p final-dist/html+js-smartwebmessaging
+          cp -r html+js-smartwebmessaging/* final-dist/html+js-smartwebmessaging/
+
       - name: Copy landing page
         run: cp index.html final-dist/
 


### PR DESCRIPTION
## Summary
- Adds workflow step to copy `html+js-smartwebmessaging/` directory during GitHub Pages deployment

## Dependencies
- Depends on #40 being merged first (adds the source directory)

## Test plan
- [ ] Merge #40 first
- [ ] Merge this PR
- [ ] Verify GitHub Pages deployment succeeds
- [ ] Verify `html+js-smartwebmessaging/` is accessible on deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)