### PR TITLE
Use raw objects instead of JSON strings for postMessage

### DIFF
--- a/html+js-smartwebmessaging/index.html
+++ b/html+js-smartwebmessaging/index.html
@@ -120,14 +120,12 @@
 
                 // Send message to host
                 sendMessage(message) {
-                    const json = JSON.stringify(message);
                     console.log('[SWM] Sending:', message.messageType, message);
 
                     if (this.isWebView2()) {
-                        window.chrome.webview.postMessage(json);
+                        window.chrome.webview.postMessage(message);
                     } else if (this.isIframe()) {
-                        // Iframe mode - send to parent window
-                        window.parent.postMessage(json, '*');
+                        window.parent.postMessage(message, '*');
                     } else {
                         console.warn('[SWM] No host available - message not sent');
                     }
@@ -167,15 +165,7 @@
                 },
 
                 // Handle incoming message from host
-                handleMessage(data) {
-                    let message;
-                    try {
-                        message = typeof data === 'string' ? JSON.parse(data) : data;
-                    } catch (e) {
-                        console.error('[SWM] Failed to parse message:', e);
-                        return;
-                    }
-
+                handleMessage(message) {
                     console.log('[SWM] Received:', message.messageType || 'response', message);
 
                     // Handle response to our request

--- a/html+js-smartwebmessaging/test-harness.html
+++ b/html+js-smartwebmessaging/test-harness.html
@@ -315,14 +315,7 @@
                 const iframe = document.getElementById('sdk-iframe');
                 if (event.source !== iframe.contentWindow) return;
 
-                let message;
-                try {
-                    message = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
-                } catch (e) {
-                    console.error('Failed to parse message:', e);
-                    return;
-                }
-
+                const message = event.data;
                 logMessage('received', message);
 
                 // Auto-respond to certain messages
@@ -339,8 +332,7 @@
             // Send message to iframe
             function sendToIframe(message) {
                 const iframe = document.getElementById('sdk-iframe');
-                const json = JSON.stringify(message);
-                iframe.contentWindow.postMessage(json, '*');
+                iframe.contentWindow.postMessage(message, '*');
                 logMessage('sent', message);
             }
 


### PR DESCRIPTION
## Summary
- Removes JSON serialization/parsing from postMessage communication
- `postMessage` can handle JavaScript objects directly without stringify/parse

## Changes
- **index.html**: Send raw objects via `postMessage(message)`, receive via `event.data` directly
- **test-harness.html**: Same - send raw objects, receive directly

## Dependencies
- Depends on #40 being merged first

## Test plan
- [ ] Merge #40 first
- [ ] Open test harness
- [ ] Verify handshake succeeds
- [ ] Verify questionnaire loads and messages flow correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)