### PR TITLE
Fix launchContext payload format to match SDC SWM spec

### DIFF
--- a/html+js-smartwebmessaging/index.html
+++ b/html+js-smartwebmessaging/index.html
@@ -320,6 +320,33 @@
             let narrative = null;
             let launchContext = null;
 
+            // Helper to extract content from launchContext item (handles content[x] polymorphism)
+            function extractLaunchContextContent(item) {
+                // Find any property starting with 'content' (contentResource, contentReference, etc.)
+                for (const key of Object.keys(item)) {
+                    if (key.startsWith('content')) {
+                        return item[key];
+                    }
+                }
+                return null;
+            }
+
+            // Helper to convert spec array format to SDK object format
+            function convertLaunchContextToObject(launchContextArray) {
+                const result = {};
+                if (Array.isArray(launchContextArray)) {
+                    launchContextArray.forEach(item => {
+                        if (item.name) {
+                            const content = extractLaunchContextContent(item);
+                            if (content) {
+                                result[item.name] = content;
+                            }
+                        }
+                    });
+                }
+                return result;
+            }
+
             function checkReadyToInitialize() {
                 // Auto-initialize is handled by sdc.displayQuestionnaire
                 // This function can be used for status updates
@@ -388,9 +415,9 @@
                     if (SmartWebMessaging.context.encounter) {
                         fillerOptions.encounter = SmartWebMessaging.context.encounter;
                     }
-                    // Pass full resources via launchContext (object with keys like 'patient', 'user')
-                    if (SmartWebMessaging.context.launchContext && Object.keys(SmartWebMessaging.context.launchContext).length > 0) {
-                        fillerOptions.launchContext = SmartWebMessaging.context.launchContext;
+                    // Convert launchContext from spec array format to SDK object format
+                    if (SmartWebMessaging.context.launchContext && Array.isArray(SmartWebMessaging.context.launchContext) && SmartWebMessaging.context.launchContext.length > 0) {
+                        fillerOptions.launchContext = convertLaunchContextToObject(SmartWebMessaging.context.launchContext);
                     }
                 }
 
@@ -416,9 +443,9 @@
                     if (SmartWebMessaging.context.encounter) {
                         launchContextOptions.encounter = SmartWebMessaging.context.encounter;
                     }
-                    // Pass full resources via launchContext (object with keys like 'patient', 'user')
-                    if (SmartWebMessaging.context.launchContext && Object.keys(SmartWebMessaging.context.launchContext).length > 0) {
-                        launchContextOptions.launchContext = SmartWebMessaging.context.launchContext;
+                    // Convert launchContext from spec array format to SDK object format
+                    if (SmartWebMessaging.context.launchContext && Array.isArray(SmartWebMessaging.context.launchContext) && SmartWebMessaging.context.launchContext.length > 0) {
+                        launchContextOptions.launchContext = convertLaunchContextToObject(SmartWebMessaging.context.launchContext);
                     }
                     console.log('[SDK] Using context from host:', SmartWebMessaging.context);
                 }

--- a/html+js-smartwebmessaging/test-harness.html
+++ b/html+js-smartwebmessaging/test-harness.html
@@ -507,18 +507,18 @@
                 const practitionerResource = getSelectedPractitionerResource();
 
                 const payload = {
-                    launchContext: {}
+                    launchContext: []
                 };
 
                 if (patientRef) payload.subject = patientRef;
                 if (practitionerRef) payload.author = practitionerRef;
 
-                // Embed full resources in launchContext as key-value pairs
+                // Embed full resources in launchContext as array per SDC SWM spec
                 if (patientResource) {
-                    payload.launchContext.patient = patientResource;
+                    payload.launchContext.push({ name: 'patient', contentResource: patientResource });
                 }
                 if (practitionerResource) {
-                    payload.launchContext.user = practitionerResource;
+                    payload.launchContext.push({ name: 'user', contentResource: practitionerResource });
                 }
 
                 sendToIframe({
@@ -535,13 +535,13 @@
                 const patientResource = getSelectedPatientResource();
                 const practitionerResource = getSelectedPractitionerResource();
 
-                // Build launchContext with full resources as key-value pairs
-                const launchContext = {};
+                // Build launchContext as array per SDC SWM spec
+                const launchContext = [];
                 if (patientResource) {
-                    launchContext.patient = patientResource;
+                    launchContext.push({ name: 'patient', contentResource: patientResource });
                 }
                 if (practitionerResource) {
-                    launchContext.user = practitionerResource;
+                    launchContext.push({ name: 'user', contentResource: practitionerResource });
                 }
 
                 sendToIframe({


### PR DESCRIPTION
## Summary
- Fixed `launchContext` field format to match the [SDC SMART Web Messaging specification](https://github.com/brianpos/sdc-smart-web-messaging/blob/main/docs/sdc-swm-protocol.md)
- Changed from incorrect object format `{ patient: resource }` to spec-compliant array format `[{ name: "patient", contentResource: resource }]`
- Added helper functions to handle the polymorphic `content[x]` field type-agnostically

## Test plan
- [ ] Open test-harness.html in browser
- [ ] Select a patient and practitioner from dropdowns
- [ ] Click "Send Questionnaire" button
- [ ] Verify in message log that `launchContext` is an array with `{ name, contentResource }` objects
- [ ] Verify the questionnaire loads and pre-population works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)