### PR TITLE
feat: add placeholder QuestionnaireResponse with narrative and diagnosis

### DIFF
--- a/html+js-smartwebmessaging/index.html
+++ b/html+js-smartwebmessaging/index.html
@@ -476,7 +476,72 @@
                         questionnaireResponse = {
                             resourceType: 'QuestionnaireResponse',
                             status: 'completed',
-                            questionnaire: 'Questionnaire/placeholder'
+                            questionnaire: 'Questionnaire/placeholder',
+                            text: {
+                                status: 'generated',
+                                div: '<div xmlns="http://www.w3.org/1999/xhtml">' +
+                                     '<h3>Specimen Information</h3>' +
+                                     '<p>Specimen type and collection details not available</p>' +
+                                     '<h3>Gross Description</h3>' +
+                                     '<p>Macroscopic examination findings pending</p>' +
+                                     '<h3>Microscopic Findings</h3>' +
+                                     '<p>Histological analysis data could not be extracted</p>' +
+                                     '<h3>Diagnosis</h3>' +
+                                     '<p>Final pathological diagnosis pending form data extraction</p>' +
+                                     '</div>',
+                                extension: [
+                                    {
+                                        url: 'http://fhir.tiro.health/StructureDefinition/narrative-alternative-format',
+                                        valueAttachment: {
+                                            contentType: 'text/rtf',
+                                            data: btoa(
+                                                '{\\rtf1\\ansi\\deff0' +
+                                                '{\\fonttbl{\\f0 Arial;}}' +
+                                                '\\f0\\fs24' +
+                                                '\\b Specimen Information\\b0\\par' +
+                                                'Specimen type and collection details not available\\par\\par' +
+                                                '\\b Gross Description\\b0\\par' +
+                                                'Macroscopic examination findings pending\\par\\par' +
+                                                '\\b Microscopic Findings\\b0\\par' +
+                                                'Histological analysis data could not be extracted\\par\\par' +
+                                                '\\b Diagnosis\\b0\\par' +
+                                                'Final pathological diagnosis pending form data extraction\\par' +
+                                                '}'
+                                            )
+                                        }
+                                    }
+                                ]
+                            },
+                            item: [
+                                {
+                                    linkId: 'diagnosis',
+                                    text: 'Diagnosis',
+                                    answer: [
+                                        {
+                                            valueCoding: {
+                                                system: 'http://snomed.info/sct',
+                                                code: '254637007',
+                                                display: 'Non-small cell lung cancer'
+                                            }
+                                        }
+                                    ],
+                                    item: [
+                                        {
+                                            linkId: 'diagnosis-codap',
+                                            text: 'CODAP Code',
+                                            answer: [
+                                                {
+                                                    valueCoding: {
+                                                        system: 'http://codap.be',
+                                                        code: '8140/3',
+                                                        display: 'Adenocarcinoma, NOS'
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
                         };
                     }
 


### PR DESCRIPTION
## Summary
- Adds a complete placeholder QuestionnaireResponse when SDK API is unavailable
- Includes pathology report narrative with HTML and RTF alternative format
- Adds diagnosis item with coded values (SNOMED-CT + CODAP)

## Changes
- **Narrative**: Pathology report sections (Specimen Information, Gross Description, Microscopic Findings, Diagnosis)
- **RTF Extension**: Uses `http://fhir.tiro.health/StructureDefinition/narrative-alternative-format` for RTF alternative
- **Diagnosis Item**: SNOMED-CT code `254637007` (Non-small cell lung cancer) with nested CODAP code `8140/3` (Adenocarcinoma, NOS)

## Test plan
- [ ] Load the SDK tutorial page in an iframe
- [ ] Trigger form submission without SDK properly initialized
- [ ] Verify placeholder QuestionnaireResponse contains narrative and diagnosis item

🤖 Generated with [Claude Code](https://claude.com/claude-code)