### PR TITLE
feat: add retry logic to smart web messaging handshake

### DIFF
--- a/html+js-smartwebmessaging/index.html
+++ b/html+js-smartwebmessaging/index.html
@@ -169,32 +169,34 @@
                     return new Promise((resolve, reject) => {
                         const startTime = Date.now();
                         let attemptCount = 0;
+                        let resolved = false;
+                        const attemptMessageIds = [];  // Track all attempt messageIds
+
+                        const cleanup = () => {
+                            // Remove all pending requests for this handshake
+                            attemptMessageIds.forEach(id => this.pendingRequests.delete(id));
+                        };
+
+                        const onSuccess = (payload) => {
+                            if (resolved) return;  // Already resolved
+                            resolved = true;
+                            cleanup();
+                            resolve(payload);
+                        };
 
                         const attempt = () => {
+                            if (resolved) return;
+
                             attemptCount++;
-                            const elapsed = Date.now() - startTime;
-
-                            if (elapsed >= timeoutMs) {
-                                reject(new Error(`Handshake timeout after ${attemptCount} attempts`));
-                                return;
-                            }
-
                             console.log(`[SWM] Handshake attempt ${attemptCount}...`);
 
                             const messageId = this.generateMessageId();
+                            attemptMessageIds.push(messageId);
+
+                            // All attempts share the same success handler
                             this.pendingRequests.set(messageId, {
-                                resolve: (payload) => {
-                                    resolve(payload);
-                                },
-                                reject: () => {
-                                    // Attempt failed, schedule next attempt if time remains
-                                    const remaining = timeoutMs - (Date.now() - startTime);
-                                    if (remaining > 0) {
-                                        attempt();
-                                    } else {
-                                        reject(new Error(`Handshake timeout after ${attemptCount} attempts`));
-                                    }
-                                }
+                                resolve: onSuccess,
+                                reject: () => {}  // Individual timeouts don't reject
                             });
 
                             this.sendMessage({
@@ -204,15 +206,24 @@
                                 payload: {}
                             });
 
-                            // Timeout this attempt after retryIntervalMs
+                            // Schedule next attempt (keep old messageId active)
                             setTimeout(() => {
-                                if (this.pendingRequests.has(messageId)) {
-                                    const pending = this.pendingRequests.get(messageId);
-                                    this.pendingRequests.delete(messageId);
-                                    pending.reject();
+                                if (!resolved) {
+                                    const remaining = timeoutMs - (Date.now() - startTime);
+                                    if (remaining > 0) {
+                                        attempt();
+                                    }
                                 }
                             }, retryIntervalMs);
                         };
+
+                        // Overall timeout
+                        setTimeout(() => {
+                            if (!resolved) {
+                                cleanup();
+                                reject(new Error(`Handshake timeout after ${attemptCount} attempts`));
+                            }
+                        }, timeoutMs);
 
                         attempt();
                     });


### PR DESCRIPTION
## Summary
- Add `retryHandshake()` method that attempts handshake every 1 second
- Keep all messageIds active until success or 30 second timeout expires
- Accept response to any pending attempt (handles slow channels)
- Update test harness to use production SDC server
- Add 3 second delay to test harness to demonstrate retry behavior

## Implementation Details
The retry logic keeps all pending messageIds active instead of discarding them on retry. This handles slow channels where the response may arrive after the retry interval but before the total timeout.

```
[SWM] Handshake attempt 1...
[SWM] Handshake attempt 2...
[SWM] Handshake attempt 3...
[SWM] Received: response to attempt 1
[SWM] Handshake successful
```

## Test plan
- [ ] Load test-harness.html and observe retry attempts in console
- [ ] Verify handshake succeeds after ~3 seconds (response to first attempt)
- [ ] Verify 30 second timeout works when host never responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)