### PR TITLE
feat: generate narrative on form submit

### DIFF
--- a/html+js-smartwebmessaging/index.html
+++ b/html+js-smartwebmessaging/index.html
@@ -570,9 +570,22 @@
             }
 
             // Called from the tiro-submit event listener
-            function sendFormSubmission(questionnaireResponse) {
+            async function sendFormSubmission(questionnaireResponse) {
                 // Mark as completed
                 questionnaireResponse.status = "completed";
+
+                // Generate narrative using SDCClient from form-filler
+                const formFiller = document.getElementById("form-filler");
+                try {
+                    const narrative = await formFiller.sdcClient.generateNarrative(questionnaireResponse);
+                    questionnaireResponse.text = {
+                        status: narrative.status || "generated",
+                        div: narrative.div,
+                    };
+                    console.log("[Action] Generated narrative:", questionnaireResponse.text);
+                } catch (err) {
+                    console.warn("[Action] Narrative generation error:", err);
+                }
 
                 const operationOutcome = {
                     resourceType: "OperationOutcome",


### PR DESCRIPTION
## Summary
- Call SDC `$generate-narrative` endpoint on form submit
- Populate `QuestionnaireResponse.text` with generated HTML narrative before sending to host
- Uses `formFiller.sdcClient.generateNarrative()` from the SDK

## Test plan
- [ ] Load questionnaire in test harness
- [ ] Fill out form and submit
- [ ] Verify console shows `[Action] Generated narrative:` log
- [ ] Check downloaded JSON has `text.div` populated with HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)