### PR TITLE
Add PostHog analytics integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -339,7 +339,7 @@
         posthog.init('phc_Hay5R4mHZSxd6IfGDqlTCDVEEKTV4c6yaCtkymKdvbx', {
             api_host: 'https://eu.i.posthog.com',
             defaults: '2026-01-30',
-            person_profiles: 'identified_only',
+            person_profiles: 'always',
         })
     </script>
 </head>

--- a/index.html
+++ b/index.html
@@ -334,6 +334,14 @@
             }
         }
     </style>
+    <script>
+        !function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="ci init Pi Ci ft Oi Fi ki capture calculateEventProperties Ui register register_once register_for_session unregister unregister_for_session Bi getFeatureFlag getFeatureFlagPayload getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty ji Di createPersonProfile setInternalOrTestUser zi Ti Hi opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing Ai debug bt Ni getPageViewId captureTraceFeedback captureTraceMetric Ei".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+        posthog.init('phc_Hay5R4mHZSxd6IfGDqlTCDVEEKTV4c6yaCtkymKdvbx', {
+            api_host: 'https://eu.i.posthog.com',
+            defaults: '2026-01-30',
+            person_profiles: 'identified_only',
+        })
+    </script>
 </head>
 <body>
     <nav class="sidebar" role="navigation" aria-label="Tutorial navigation">


### PR DESCRIPTION
## Summary
This PR adds PostHog analytics tracking to the application by integrating the PostHog SDK into the HTML document.

## Changes
- Added PostHog initialization script to `index.html`
- Configured PostHog with:
  - Project key: `phc_Hay5R4mHZSxd6IfGDqlTCDVEEKTV4c6yaCtkymKdvbx`
  - API host: `https://eu.i.posthog.com` (EU region)
  - Person profiles: enabled with `always` mode
  - Default date configuration: `2026-01-30`

## Implementation Details
The PostHog SDK is loaded asynchronously via a script tag in the document head, ensuring it doesn't block page rendering. The initialization includes a stub function that queues analytics calls until the full SDK is loaded.

https://claude.ai/code/session_016PwUc1Cw5RvTJDopXQPRWT